### PR TITLE
Adding na.rm to draw_canvas()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: This package draws protein schematics from Uniprot API output.
     From the JSON returned by the GET command, it creates a dataframe from the 
     Uniprot Features API. This dataframe can then be used by geoms based on 
     ggplot2 and base R to draw protein schematics. 
-Depends: R (>= 3.5)
+Depends: R (>= 3.4)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: false

--- a/R/geoms.R
+++ b/R/geoms.R
@@ -30,8 +30,8 @@ draw_canvas <- function(data = data){
     begin=end=NULL
     p <- ggplot2::ggplot()
     p <- p + ggplot2::ylim(0.5, max(data$order)+0.5)
-    p <- p + ggplot2::xlim(-max(data$end)*0.2,
-                            max(data$end) + max(data$end)*0.1)
+    p <- p + ggplot2::xlim(-max(data$end, na.rm=TRUE)*0.2,
+        max(data$end, na.rm=TRUE) + max(data$end, na.rm=TRUE)*0.1)
     p <- p + ggplot2::labs(x = "Amino acid number") # label x-axis
     p <- p + ggplot2::labs(y = "") # label y-axis
 


### PR DESCRIPTION
Further exploration shows that if a NA is introduced due to unexpected
symbol in end value UniProt (e.g. question mark in P78423 -
http://www.uniprot.org/uniprot/P78423) will cause draw_canvas() to
fail.

Introduction of na.rm prevents thins.