### PR TITLE
Add 1 chain if missing

### DIFF
--- a/R/extract_from_api.R
+++ b/R/extract_from_api.R
@@ -119,6 +119,16 @@ extract_feat_acc <- function(features_list){
     features_dataframe$length <-
         features_dataframe$end - features_dataframe$begin
 
+    # Add 1 chain if missing
+    if(!any(features_dataframe$type=="CHAIN")){
+        features_dataframe <- rbind(features_dataframe,
+                                    data.frame(type = "CHAIN",
+                                               description = "NONE",
+                                               begin = 1,
+                                               end = nchar(features_list$sequence),
+                                               length = nchar(features_list$sequence) - 1))
+    }
+
     # add accession number to each row of dataframe
     features_dataframe$accession <- rep(features_list$accession,
         times = nrow(features_dataframe))

--- a/tests/testthat/test-extract_features_acc.R
+++ b/tests/testthat/test-extract_features_acc.R
@@ -78,6 +78,31 @@ test_that("extract_feat_acc works to give ",{
 
 })
 
+test_that("extract_feat_acc works with no chains ",{
+
+  # load data from the package - should I move it into the test folder
+  data("rel_A_features")  # this is object created from whole Uniprot GET
+  # creates JSON object  in the environment.
+  # it's the json data for Q04206 - for the transcription factor RelA
+
+  # remove chain feature
+  rel_A_features$features[[1]] <- NULL
+
+  # Nice simple test
+  res <- extract_feat_acc(rel_A_features)
+
+  expect_is(res, "data.frame") # generic
+
+  # Chain should be added, exactly 1
+  expect_equal(sum(res$type=="CHAIN"), 1) # exact for sample data
+  expect_equal(res[which(res$type=="CHAIN"),]$end, max(res$end)) # no feature should be outside the chain
+
+  expect_equal(nrow(res), 75)  # exact for sample data
+  expect_match(colnames(res)[3], "begin") # 3rd column name is begin
+  expect_match(colnames(res)[4], "end") # 4th column name is end
+  expect_match(colnames(res)[6], "accession") # 6th column name is accession
+
+})
 
 
 # write function to do unit tests with is extract_names


### PR DESCRIPTION
This is a great package thanks for putting it together! I came across one problem in that many proteins in uniprot have no annotated chain, so I added some code to add a chain if it's missing using the sequence length contained in the json.

Reproducible example of problem:

``` r
library(drawProteins)
rel_json <- drawProteins::get_features("Q96J94 E2RDH8 G3RI55 U3IY01 H2Q773")
#> [1] "Download has worked"
rel_data <- drawProteins::feature_to_dataframe(rel_json)
p <- draw_canvas(rel_data)
p <- draw_chains(p, rel_data)
p <- draw_domains(p, rel_data, label_domains = F)
p
```

![](https://i.imgur.com/MeOqkpY.png)

<sup>Created on 2019-08-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>