### PR TITLE
use y-axis labels to label proteins

### DIFF
--- a/R/geoms.R
+++ b/R/geoms.R
@@ -30,8 +30,8 @@ draw_canvas <- function(data = data){
     begin=end=NULL
     p <- ggplot2::ggplot()
     p <- p + ggplot2::ylim(0.5, max(data$order)+0.5)
-    p <- p + ggplot2::xlim(-max(data$end, na.rm=TRUE)*0.2,
-        max(data$end, na.rm=TRUE) + max(data$end, na.rm=TRUE)*0.1)
+    p <- p + ggplot2::xlim(-max(data$end, na.rm=TRUE)*0.1,
+                           max(data$end, na.rm=TRUE) + max(data$end, na.rm=TRUE)*0.1)
     p <- p + ggplot2::labs(x = "Amino acid number") # label x-axis
     p <- p + ggplot2::labs(y = "") # label y-axis
 
@@ -106,11 +106,8 @@ draw_chains <- function(p,
 
     if(label_chains == TRUE){
         p <- p +
-            ggplot2::annotate("text", x = -10,
-                y = data[data$type == "CHAIN",]$order,
-                        label = labels,
-                        hjust = 1,
-                        size = label_size)
+            scale_y_continuous(breaks = seq_along(unique(labels)),
+                               labels = unique(labels))
     }
     return(p)
 }


### PR DESCRIPTION
Using annotate for chain labels sometimes clips the start of the label.

I changed to instead use the breaks and labels argument in scale_y_continuous which automatically handles resizing things such that the label is always readable.

You could of course use + xlim(-200,NA) but you have to manually set the minimum value and you get a random "-200" on the x-axis label which is in the middle of nowhere if you have a plain background. It seems simpler to use the machinary for axis labels which is already built into ggplot, given these chain labels are in effect axis labels? This also fixes a bug in that proteins with multiple chains have bold labels compared to the others due to ploting the label for each chain.

Example showing probelm:

``` r
library(drawProteins)
rel_json <- drawProteins::get_features("Q9UGP5 Q9FNY4 Q9QXE2 Q67VC8 P07683")
#> [1] "Download has worked"
rel_data <- drawProteins::feature_to_dataframe(rel_json)
p <- draw_canvas(rel_data)
p <- draw_chains(p, rel_data)
p <- draw_domains(p, rel_data)
p
```

![](https://i.imgur.com/I27DQwa.png)

<sup>Created on 2019-08-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>