### PR TITLE
Enable custom domain types

### DIFF
--- a/R/geoms.R
+++ b/R/geoms.R
@@ -150,9 +150,10 @@ draw_domains <- function(p,
                         data = data,
                         label_domains = TRUE,
                         label_size = 4,
-                        show.legend = TRUE){
+                        show.legend = TRUE,
+                        type = "DOMAIN"){
     begin=end=description=NULL
-    p <- p + ggplot2::geom_rect(data= data[data$type == "DOMAIN",],
+    p <- p + ggplot2::geom_rect(data= data[data$type == type,],
             mapping=ggplot2::aes(xmin=begin,
                         xmax=end,
                         ymin=order-0.25,
@@ -161,7 +162,7 @@ draw_domains <- function(p,
                         show.legend = show.legend)
 
     if(label_domains == TRUE){
-        p <- p + ggplot2::geom_label(data = data[data$type == "DOMAIN", ],
+        p <- p + ggplot2::geom_label(data = data[data$type == type, ],
                         ggplot2::aes(x = begin + (end-begin)/2,
                             y = order,
                             label = description),


### PR DESCRIPTION
to enable adding e.g. of ZN_FING
This seems a more scalable solution than having a new draw_x() for every type (re issue #13)

With this PR change, you can pass an argument of the type of element you want to plot e.g:

```
rel_json <- get_features("Q9NX47")
rel_data <- feature_to_dataframe(rel_json)
p <- draw_canvas(rel_data)
p <- draw_chains(p, rel_data)
p <- draw_domains(p, rel_data, type="ZN_FING")
p
```

It also means that code for geoms like draw_recept_dom() could be simplified to:

```
draw_recept_dom2 <- function(p,
                            data = data,
                            label_domains = FALSE,
                            label_size = 4,
                            show.legend = TRUE){

    p <- draw_domains(p, data, label_domains, label_size, show.legend, "TOPO_DOM")
    p <- draw_domains(p, data, label_domains, label_size, show.legend, "TRANSMEM")

    return(p)
}
```

but I leave that for you to decide